### PR TITLE
Added null check

### DIFF
--- a/Conservatorio/Rdio/Api.cs
+++ b/Conservatorio/Rdio/Api.cs
@@ -251,8 +251,12 @@ namespace Conservatorio.Rdio
 		{
 			foreach (var property in await CoreGetObjectsAsync (keys)) {
 				var obj = RdioObject.FromJson (property.Value);
-				targetStore.Add (obj);
-				objectLoaded?.Invoke (obj);
+				if (obj != null) {
+					targetStore.Add (obj);
+					objectLoaded?.Invoke (obj);
+				} else {
+					Console.WriteLine ("Couldn't add {0}", property.Value);
+				}
 			}
 		}
 


### PR DESCRIPTION
A couple items returned null in 

`var obj = RdioObject.FromJson (property.Value);`

so I added this to get the majority of the output from my library to complete.

Output of items that returned null is here: https://gist.github.com/mikebluestein/9c6726457b6c399460a9

Thanks for writing this app. Sorry about Rdio :(
